### PR TITLE
Feat: Cannot start tiden on MacOS without watchman install

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ _Build flexible web apps using modern native web technology_
 
 ## Get started
 
+- Prerequisite: to start dev-server on local, you need to install `watchman` on:
+  + [Linus/MacOS](https://facebook.github.io/watchman/docs/install.html#linux-and-macos)
+  + [Window](https://facebook.github.io/watchman/docs/install.html#windows)
+
 ```
 npm install -g tiden
 tiden init <project name> [-d "project description"]

--- a/cli.js
+++ b/cli.js
@@ -6,6 +6,12 @@ try {
   const [cmd, ...args] = parse(...process.argv.slice(2))
   cmd(...args)
 } catch (e) {
-  console.error(e.message)
+
+  if (e.message.includes('spawn watchman')) {
+    console.log('Please check if watchman is installed properly, before using dev-server!')
+  } else {
+    console.error(e.message)
+  }
+
   process.exit(1)
 }


### PR DESCRIPTION
1. Add error handle in cli, when dev machine missing watchman
2. Add README guide to install watchmane