### PR TITLE
CLI to assume namespace from cwd #19

### DIFF
--- a/ops/createComponent.js
+++ b/ops/createComponent.js
@@ -16,15 +16,15 @@ export default async function createComponent({
   css,
 }) {
 
-  const havePath = path !== `` && path !== `/` && path !== `./` && path !== undefined
+  const emptyPath = path === `` || path === `/` || path === `./` || path === undefined
   const notInAppDir = process.cwd().indexOf(`/app`) === -1
-  const noAppPath = !havePath || path?.indexOf(`app`) === -1
+  const noAppPath = emptyPath || path?.indexOf(`app/`) === -1
 
-  if (notInAppDir && noAppPath) {
+  if (path !== `app` && notInAppDir && noAppPath) {
     throw new Error(`Cannot create component outside app directory`)
   }
 
-  const resolvePath = havePath ? path : ``
+  const resolvePath = !emptyPath ? path : ``
   const componentPath = resolvePath ? `${resolvePath}/components` : `components`
   const file = `${componentPath}/${name}.js`
   const demo = `${componentPath}/${name}/demo.js`

--- a/ops/createComponent.js
+++ b/ops/createComponent.js
@@ -15,26 +15,16 @@ export default async function createComponent({
   args,
   css,
 }) {
+
   const havePath = path !== `` && path !== `/` && path !== `./` && path !== undefined
-  const haveAppDir = process.cwd().indexOf(`/app/`) !== -1
-  let resolvePath
+  const notInAppDir = process.cwd().indexOf(`/app`) === -1
+  const noAppPath = !havePath || path?.indexOf(`app`) === -1
 
-  if (havePath && haveAppDir)  {
-    resolvePath = path
+  if (notInAppDir && noAppPath) {
+    throw new Error(`Cannot create component outside app directory`)
   }
 
-  if (!havePath && !haveAppDir)  {
-    resolvePath = `app`
-  }
-
-  if (!havePath && haveAppDir)  {
-    resolvePath = ``
-  }
-
-  if (havePath && !haveAppDir)  {
-    resolvePath = `app/${path}/`
-  }
-
+  const resolvePath = havePath ? path : ``
   const componentPath = resolvePath ? `${resolvePath}/components` : `components`
   const file = `${componentPath}/${name}.js`
   const demo = `${componentPath}/${name}/demo.js`
@@ -52,7 +42,9 @@ export default async function createComponent({
 }
 
 async function createComponentFile(path, name, file, body, imports, args = []) {
-  const nss = path ? path.split(`/`).filter(dir => dir !== `app` && !!dir) : []
+  const appDirIndex = process.cwd().indexOf(`/app`)
+  const namespace = (appDirIndex !== -1) ? process.cwd().substr(appDirIndex + 4) : ``
+  const nss = namespace ? namespace.split(`/`).filter(dir => !!dir) : []
   const allImports = importsBuilder({
     tiden: {
       html: [`html`],

--- a/ops/createComponent.js
+++ b/ops/createComponent.js
@@ -8,23 +8,16 @@ import camelToSnake from "../lib/camelToSnake.js"
 import importsBuilder from "./importsBuilder.js"
 
 export default async function createComponent({
-  path,
+  path = ``,
   name,
   body,
   imports,
   args,
   css,
 }) {
-
-  const emptyPath = path === `` || path === `/` || path === `./` || path === undefined
-  const notInAppDir = process.cwd().indexOf(`/app`) === -1
-  const noAppPath = emptyPath || path?.indexOf(`app/`) === -1
-
-  if (path !== `app` && notInAppDir && noAppPath) {
-    throw new Error(`Cannot create component outside app directory`)
-  }
-
-  const resolvePath = !emptyPath ? path : ``
+  const isInApp = process.cwd().indexOf(`/app`) !== -1
+  const isAppPath = path?.startsWith(`app`)
+  const resolvePath = (isInApp || isAppPath) ? path : `app/` + path
   const componentPath = resolvePath ? `${resolvePath}/components` : `components`
   const file = `${componentPath}/${name}.js`
   const demo = `${componentPath}/${name}/demo.js`

--- a/ops/createComponent.js
+++ b/ops/createComponent.js
@@ -15,26 +15,44 @@ export default async function createComponent({
   args,
   css,
 }) {
-  const realPath = path ? `app/${path}` : `app`
-  path = path || ``
+  const havePath = path !== `` && path !== `/` && path !== `./` && path !== undefined
+  const haveAppDir = process.cwd().indexOf(`/app/`) !== -1
+  let resolvePath
 
-  const file = `${realPath}/components/${name}.js`
-  const demo = `${realPath}/components/${name}/demo.js`
-  const cssFile = `${realPath}/components/${name}/css.js`
+  if (havePath && haveAppDir)  {
+    resolvePath = path
+  }
+
+  if (!havePath && !haveAppDir)  {
+    resolvePath = `app`
+  }
+
+  if (!havePath && haveAppDir)  {
+    resolvePath = ``
+  }
+
+  if (havePath && !haveAppDir)  {
+    resolvePath = `app/${path}/`
+  }
+
+  const componentPath = resolvePath ? `${resolvePath}/components` : `components`
+  const file = `${componentPath}/${name}.js`
+  const demo = `${componentPath}/${name}/demo.js`
+  const cssFile = `${componentPath}/${name}/css.js`
   const exists = await fileExists(file)
 
   if (exists) {
     throw new Error(`A component '${name}' already exists`)
   }
 
-  await mkdirp(realPath + `/components/${name}`)
-  await createComponentFile(path, name, file, body, imports, args)
-  await createCss(path, name, cssFile, css)
-  await createComponentDemo(path, name, demo)
+  await mkdirp(`${componentPath}/${name}`)
+  await createComponentFile(resolvePath, name, file, body, imports, args)
+  await createCss(resolvePath, name, cssFile, css)
+  await createComponentDemo(resolvePath, name, demo)
 }
 
 async function createComponentFile(path, name, file, body, imports, args = []) {
-  const nss = path ? path.split(`/`) : []
+  const nss = path ? path.split(`/`).filter(dir => dir !== `app` && !!dir) : []
   const allImports = importsBuilder({
     tiden: {
       html: [`html`],

--- a/ops/createComponent.test.js
+++ b/ops/createComponent.test.js
@@ -29,14 +29,14 @@ describe(`createComponent`, () => {
 
     it(`should throw an error`, async () => {
       try {
-        await createComponent({ path: `app/one`, name: `myComponent` })
+        await createComponent({ path: `one`, name: `myComponent` })
         throw new Error(`It did not throw an error`)
       } catch (e) {
         expect(e.message).to.equal(`A component 'myComponent' already exists`)
       }
     })
   })
-
+    /*
   describe(`when create outside app dir`, () => {
     beforeEach(async () => {
       await mkdirp(`app/one/two/three`)
@@ -51,7 +51,7 @@ describe(`createComponent`, () => {
       }
     })
   })
-
+  */
   describe(`with no existing component`, () => {
     beforeEach(async () => {
       await createComponent({ path: `app/one`, name: `myComponent` })
@@ -145,7 +145,7 @@ describe(`createComponent`, () => {
   describe(`with body`, () => {
     beforeEach(async () => {
       await createComponent({
-        path: `app/one`,
+        path: `one`,
         name: `myComponent`,
         body: o`
           return html\`Muppet show\`
@@ -163,7 +163,6 @@ describe(`createComponent`, () => {
   describe(`with imports`, () => {
     beforeEach(async () => {
       await createComponent({
-        path: `app`,
         name: `myComponent`,
         imports: {
           "../someLib.js": {
@@ -183,7 +182,6 @@ describe(`createComponent`, () => {
   describe(`with args`, () => {
     beforeEach(async () => {
       await createComponent({
-        path: `app`,
         name: `myComponent`,
         args: [`items`],
       })
@@ -199,7 +197,6 @@ describe(`createComponent`, () => {
   describe(`with css`, () => {
     beforeEach(async () => {
       await createComponent({
-        path: `app`,
         name: `myComponent`,
         css: o`
           :host {

--- a/ops/createComponent.test.js
+++ b/ops/createComponent.test.js
@@ -36,25 +36,10 @@ describe(`createComponent`, () => {
       }
     })
   })
-    /*
-  describe(`when create outside app dir`, () => {
-    beforeEach(async () => {
-      await mkdirp(`app/one/two/three`)
-    })
 
-    it(`should throw an error`, async () => {
-      try {
-        await createComponent({ name: `myComponent` })
-        throw new Error(`It did not throw an error`)
-      } catch (e) {
-        expect(e.message).to.equal(`Cannot create component outside app directory`)
-      }
-    })
-  })
-  */
   describe(`with no existing component`, () => {
     beforeEach(async () => {
-      await createComponent({ path: `app/one`, name: `myComponent` })
+      await createComponent({ path: `one`, name: `myComponent` })
     })
 
     it(`should create component`, async () => {

--- a/ops/createComponent.test.js
+++ b/ops/createComponent.test.js
@@ -61,9 +61,77 @@ describe(`createComponent`, () => {
     })
   })
 
-  describe(`with no namespace`, () => {
+  describe(`with 1 level namespace`, async () => {
     beforeEach(async () => {
-      await createComponent({ name: `myComponent` })
+      await createComponent({ name: `myComponent`, path: `one` })
+    })
+
+    it(`should create component`, async () => {
+      expect(await read(`app/one/components/myComponent.js`)).to.match(
+        /component\(.*\)/
+      )
+    })
+  })
+
+  describe(`with 2 level namespace`, async () => {
+    beforeEach(async () => {
+      await createComponent({ name: `myComponent`, path: `one/two` })
+    })
+
+    it(`should create component`, async () => {
+      expect(await read(`app/one/two/components/myComponent.js`)).to.match(
+        /component\(.*\)/
+      )
+    })
+  })
+
+  describe(`with namespace but cwd inside a dir [app/east]`, async () => {
+    beforeEach(async () => {
+      await mkdirp(`app/east`)
+      process.chdir(`app/east`)
+      await createComponent({ name: `myComponent`, path: `asia`})
+    })
+
+    it(`should create component`, async () => {
+      expect(await read(`asia/components/myComponent.js`)).to.match(
+        /component\(.*\)/
+      )
+    })
+  })
+
+  describe(`with no-namespace but cwd inside a dir [app/east]`, async () => {
+    beforeEach(async () => {
+      await mkdirp(`app/east`)
+      process.chdir(`app/east`)
+      await createComponent({ name: `myComponent`})
+    })
+
+    it(`should create component`, async () => {
+      expect(await read(`components/myComponent.js`)).to.match(
+        /component\(.*\)/
+      )
+    })
+  })
+
+  describe(`with no-namespace but cwd inside a multi-level dir [app/east/asia]`, async () => {
+    beforeEach(async () => {
+      await mkdirp(`app/east/asia`)
+      process.chdir(`app/east/asia`)
+      await createComponent({ name: `myComponent`})
+    })
+
+    it(`should create component`, async () => {
+      expect(await read(`components/myComponent.js`)).to.match(
+        /component\(.*\)/
+      )
+    })
+  })
+
+  describe(`with no-namespace and no-app-dir`, async () => {
+    beforeEach(async () => {
+      await mkdirp(`east`)
+      process.chdir(`east`)
+      await createComponent({ name: `myComponent`})
     })
 
     it(`should create component`, async () => {

--- a/ops/createComponent.test.js
+++ b/ops/createComponent.test.js
@@ -29,7 +29,7 @@ describe(`createComponent`, () => {
 
     it(`should throw an error`, async () => {
       try {
-        await createComponent({ path: `one`, name: `myComponent` })
+        await createComponent({ path: `app/one`, name: `myComponent` })
         throw new Error(`It did not throw an error`)
       } catch (e) {
         expect(e.message).to.equal(`A component 'myComponent' already exists`)
@@ -37,9 +37,24 @@ describe(`createComponent`, () => {
     })
   })
 
+  describe(`when create outside app dir`, () => {
+    beforeEach(async () => {
+      await mkdirp(`app/one/two/three`)
+    })
+
+    it(`should throw an error`, async () => {
+      try {
+        await createComponent({ name: `myComponent` })
+        throw new Error(`It did not throw an error`)
+      } catch (e) {
+        expect(e.message).to.equal(`Cannot create component outside app directory`)
+      }
+    })
+  })
+
   describe(`with no existing component`, () => {
     beforeEach(async () => {
-      await createComponent({ path: `one`, name: `myComponent` })
+      await createComponent({ path: `app/one`, name: `myComponent` })
     })
 
     it(`should create component`, async () => {
@@ -63,7 +78,7 @@ describe(`createComponent`, () => {
 
   describe(`with 1 level namespace`, async () => {
     beforeEach(async () => {
-      await createComponent({ name: `myComponent`, path: `one` })
+      await createComponent({ path: `app/one`, name: `myComponent` })
     })
 
     it(`should create component`, async () => {
@@ -75,7 +90,7 @@ describe(`createComponent`, () => {
 
   describe(`with 2 level namespace`, async () => {
     beforeEach(async () => {
-      await createComponent({ name: `myComponent`, path: `one/two` })
+      await createComponent({ path: `app/one/two`, name: `myComponent` })
     })
 
     it(`should create component`, async () => {
@@ -89,7 +104,7 @@ describe(`createComponent`, () => {
     beforeEach(async () => {
       await mkdirp(`app/east`)
       process.chdir(`app/east`)
-      await createComponent({ name: `myComponent`, path: `asia`})
+      await createComponent({ path: `asia`, name: `myComponent` })
     })
 
     it(`should create component`, async () => {
@@ -127,24 +142,10 @@ describe(`createComponent`, () => {
     })
   })
 
-  describe(`with no-namespace and no-app-dir`, async () => {
-    beforeEach(async () => {
-      await mkdirp(`east`)
-      process.chdir(`east`)
-      await createComponent({ name: `myComponent`})
-    })
-
-    it(`should create component`, async () => {
-      expect(await read(`app/components/myComponent.js`)).to.match(
-        /component\(.*\)/
-      )
-    })
-  })
-
   describe(`with body`, () => {
     beforeEach(async () => {
       await createComponent({
-        path: `one`,
+        path: `app/one`,
         name: `myComponent`,
         body: o`
           return html\`Muppet show\`
@@ -162,6 +163,7 @@ describe(`createComponent`, () => {
   describe(`with imports`, () => {
     beforeEach(async () => {
       await createComponent({
+        path: `app`,
         name: `myComponent`,
         imports: {
           "../someLib.js": {
@@ -181,6 +183,7 @@ describe(`createComponent`, () => {
   describe(`with args`, () => {
     beforeEach(async () => {
       await createComponent({
+        path: `app`,
         name: `myComponent`,
         args: [`items`],
       })
@@ -196,6 +199,7 @@ describe(`createComponent`, () => {
   describe(`with css`, () => {
     beforeEach(async () => {
       await createComponent({
+        path: `app`,
         name: `myComponent`,
         css: o`
           :host {


### PR DESCRIPTION
1. If no namespace indicate => check for app dir existed
    1.1 No app dir existed => create app/components/[name]
    1.2 App dir existed => create components/[name]
2. with namespace indicate => start from current dir

@mikabytes  during implementation, i found some edge case about create component outside app directory, so i've some assumption base on the previous code, whole logic:
```
// path given: east/asia
// cwd: app
// => app/east/asia/components/test
if (havePath && haveAppDir)  {
    resolvePath = path
}


// path given: ''
// cwd: 'cannot find app directory in absolute path by cwd'
// => app/components/test
if (!havePath && !haveAppDir)  {
    resolvePath = `app`
}

// path given: ''
// cwd: app/east/asia
// => app/east/asia/components/test
if (!havePath && haveAppDir)  {
    resolvePath = ``
}

// path given: 'east/asia'
// cwd: 'cannot find app directory in absolute path by cwd'
// => app/east/asia/components/test
if (havePath && !haveAppDir)  {
    resolvePath = `app/${path}/`
}
```

test case included, i still a little confuse on those edge cases, so if you found it reasonable i will apply to other create commands