### PR TITLE
Fix: cli allow name with dash

### DIFF
--- a/cli/parse.js
+++ b/cli/parse.js
@@ -54,6 +54,11 @@ export default function run(...slice) {
           `Usage: create <thing> <name> [path] (where thing can be 'stream', 'component', 'page' or 'nano')`
         )
       }
+      const excludeChars = /[-_\s]/g;
+      const haveExcludeChars = name.search(excludeChars) !== -1
+      if (haveExcludeChars) {
+        throw new Error(`[name] of creating page/stream/nano/component should be camelCase`)
+      }
 
       return create(noun, name, path, parsed)
     }

--- a/cli/parse.test.js
+++ b/cli/parse.test.js
@@ -73,6 +73,15 @@ describe(`cli`, () => {
         { name: `myPage`, path: undefined, pathname: `/` },
       ])
     })
+
+    it(`should fail with non camelCase name`, () => {
+      try {
+        parse(`create`, `page`, `hyphen-page_`, `ns1/ns2`)
+        throw new Error(`It did not throw an error`)
+      } catch (e) {
+        expect(e.message).to.equal(`[name] of creating page/stream/nano/component should be camelCase`)
+      }
+    })
   })
 
   describe(`create stream`, () => {
@@ -88,6 +97,16 @@ describe(`cli`, () => {
         [createStream, { name: `myStream`, path: `ns1/ns2` }]
       )
     })
+
+    it(`should fail with non camelCase name`, () => {
+      try {
+        parse(`create`, `stream`, `under_score`, `ns1/ns2`)
+        throw new Error(`It did not throw an error`)
+      } catch (e) {
+        expect(e.message).to.equal(`[name] of creating page/stream/nano/component should be camelCase`)
+      }
+    })
+
   })
 
   describe(`create nano`, () => {
@@ -104,6 +123,16 @@ describe(`cli`, () => {
         { name: `myNano`, path: `ns1/ns2` },
       ])
     })
+
+    it(`should fail with non camelCase name`, () => {
+      try {
+        parse(`create`, `nano`, `hy-phen`, `ns1/ns2`)
+        throw new Error(`It did not throw an error`)
+      } catch (e) {
+        expect(e.message).to.equal(`[name] of creating page/stream/nano/component should be camelCase`)
+      }
+    })
+
   })
 
   describe(`create component`, () => {
@@ -121,6 +150,15 @@ describe(`cli`, () => {
         createComponent,
         { name: `myComponent`, path: `ns1/ns2` },
       ])
+    })
+
+    it(`should fail with non camelCase name`, () => {
+      try {
+        parse(`create`, `component`, `hy-phen`, `ns1/ns2`)
+        throw new Error(`It did not throw an error`)
+      } catch (e) {
+        expect(e.message).to.equal(`[name] of creating page/stream/nano/component should be camelCase`)
+      }
     })
   })
 


### PR DESCRIPTION
If create page/stream/nano/component with name include hyphen/underscore/space will throw error